### PR TITLE
feat: add `ToUpper` string changer

### DIFF
--- a/docs/stringplanmodifier/index.md
+++ b/docs/stringplanmodifier/index.md
@@ -27,3 +27,4 @@ import (
 ### StringChange
 
 - [`ToLower`](tolower.md) - Converts the string to lowercase.
+- [`ToUpper`](toupper.md) - Converts the string to uppercase.

--- a/docs/stringplanmodifier/toupper.md
+++ b/docs/stringplanmodifier/toupper.md
@@ -1,0 +1,49 @@
+# `ToUpper`
+
+This plan modifier is used to force the string to be uppercase.
+
+## Who to use
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "name": schema.StringAttribute{
+                Optional:            true,
+                MarkdownDescription: "A name for ...",
+                PlanModifiers: []planmodifier.String{
+                    fstringplanmodifier.ToUpper(),
+                },
+            },
+```
+
+```tf title="main.tf"
+resource "resource_x" "example" {
+  name = "foo"
+}
+```
+
+```tf title="terraform.tfstate"
+{
+  "version": 4,
+  "terraform_version": "1.0.0",
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "resource_x",
+      "name": "example",
+      "provider": "provider[\"registry.terraform.io/hashicorp/x\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "example",
+            "name": "FOO",
+          },
+        },
+      ],
+    },
+  ],
+}
+```

--- a/stringplanmodifier/to_upper.go
+++ b/stringplanmodifier/to_upper.go
@@ -1,0 +1,19 @@
+// Package stringplanmodifier provides a plan modifier for string values.
+package stringplanmodifier
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+func ToUpper() planmodifier.String {
+	return setChangeStringFunc(
+		func(_ context.Context, req planmodifier.StringRequest, resp *StringChangeFuncResponse) {
+			resp.Value = strings.ToUpper(req.ConfigValue.ValueString())
+		},
+		"Force to upper case",
+		"Force to upper case",
+	)
+}

--- a/stringplanmodifier/to_upper_test.go
+++ b/stringplanmodifier/to_upper_test.go
@@ -1,0 +1,58 @@
+// Package stringplanmodifier provides a plan modifier for string values.
+package stringplanmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/FrangipaneTeam/terraform-plugin-framework-planmodifiers/stringplanmodifier"
+)
+
+func TestToUpperPlanModifyString(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		exceptedVal types.String
+		expectError bool
+	}
+
+	tests := map[string]testCase{
+		"unknown String": {
+			val:         types.StringUnknown(),
+			exceptedVal: types.StringNull(),
+		},
+		"null String": {
+			val:         types.StringNull(),
+			exceptedVal: types.StringNull(),
+		},
+		"valid String": {
+			val:         types.StringValue("test"),
+			exceptedVal: types.StringValue("TEST"),
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := planmodifier.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    test.val,
+			}
+
+			resp := &planmodifier.StringResponse{}
+			stringplanmodifier.ToUpper().PlanModifyString(context.Background(), request, resp)
+
+			if diff := cmp.Diff(test.exceptedVal, resp.PlanValue); diff != "" && !test.expectError {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This plan modifier is used to force the string to be uppercase.

```
go test -timeout 30s -run ^TestToUpperPlanModifyString$ github.com/FrangipaneTeam/terraform-plugin-framework-planmodifiers/stringplanmodifier

ok  	github.com/FrangipaneTeam/terraform-plugin-framework-planmodifiers/stringplanmodifier	0.512s
```